### PR TITLE
[예외 처리] 커스텀 예외 처리 구현(#9)

### DIFF
--- a/be/src/main/java/yeonba/be/exception/ExceptionAdvice.java
+++ b/be/src/main/java/yeonba/be/exception/ExceptionAdvice.java
@@ -24,27 +24,24 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
   @ExceptionHandler(value = GeneralException.class)
   public ResponseEntity<Object> handleGeneralException(
       GeneralException exception,
-      HttpServletRequest request
-  ) {
+      HttpServletRequest request) {
 
     return handleExceptionInternal(
         exception,
-        request
-    );
+        request);
   }
 
   @ExceptionHandler(value = ConstraintViolationException.class)
   public ResponseEntity<Object> handleConstraintViolationException(
       ConstraintViolationException exception,
-      WebRequest request
-  ) {
+      WebRequest request) {
 
     String exceptionMessage = getConstraintViolationMessage(exception);
+
     return handleExceptionInternalConstraint(
         exception,
         exceptionMessage,
-        request
-    );
+        request);
   }
 
   @Override
@@ -52,44 +49,40 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
       MethodArgumentNotValidException exception,
       HttpHeaders headers,
       HttpStatusCode status,
-      WebRequest request
-  ) {
+      WebRequest request) {
 
     Map<String, String> exceptionArgs = getMethodArgumentExceptionArgs(exception);
+
     return handleExceptionInternalArgs(
         exception,
         exceptionArgs,
-        request
-    );
+        request);
   }
 
   @ExceptionHandler
   public ResponseEntity<Object> handleAllException(
       Exception exception,
-      WebRequest request
-  ) {
+      WebRequest request) {
 
     return handleExceptionInternal(
         exception,
         request,
-        exception.getMessage()
-    );
+        exception.getMessage());
   }
 
   private ResponseEntity<Object> handleExceptionInternal(
       GeneralException exception,
-      HttpServletRequest request
-  ) {
+      HttpServletRequest request) {
 
     CustomResponse<Object> body = new CustomResponse<>(exception.getExceptionReason());
     WebRequest webRequest = new ServletWebRequest(request);
+
     return super.handleExceptionInternal(
         exception,
         body,
         HttpHeaders.EMPTY,
         exception.getHttpStatus(),
-        webRequest
-    );
+        webRequest);
   }
 
   private Map<String, String> getMethodArgumentExceptionArgs(
@@ -117,23 +110,22 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
   private ResponseEntity<Object> handleExceptionInternalArgs(
       MethodArgumentNotValidException exception,
       Map<String, String> exceptionArgs,
-      WebRequest request
-  ) {
+      WebRequest request) {
 
     CustomResponse<Map<String, String>> body = CustomResponse.onFailure(
         ExceptionType.BAD_REQUEST.getReason(),
-        exceptionArgs
-    );
+        exceptionArgs);
+
     return super.handleExceptionInternal(
         exception,
         body,
         HttpHeaders.EMPTY,
         ExceptionType.BAD_REQUEST.getHttpStatus(),
-        request
-    );
+        request);
   }
 
   private String getConstraintViolationMessage(ConstraintViolationException exception) {
+
     return exception.getConstraintViolations().stream()
         .map(ConstraintViolation::getMessage)
         .findFirst()
@@ -143,35 +135,32 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
   private ResponseEntity<Object> handleExceptionInternalConstraint(
       ConstraintViolationException exception,
       String exceptionMessage,
-      WebRequest request
-  ) {
+      WebRequest request) {
 
     CustomResponse<Object> body = new CustomResponse<>(exceptionMessage);
+
     return super.handleExceptionInternal(
         exception,
         body,
         HttpHeaders.EMPTY,
         ExceptionType.BAD_REQUEST.getHttpStatus(),
-        request
-    );
+        request);
   }
 
   private ResponseEntity<Object> handleExceptionInternal(
       Exception exception,
       WebRequest request,
-      String errorPoint
-  ) {
+      String errorPoint) {
 
     CustomResponse<String> body = CustomResponse.onFailure(
         ExceptionType.INTERNAL_SERVER_ERROR.getReason(),
-        errorPoint
-    );
+        errorPoint);
+
     return super.handleExceptionInternal(
         exception,
         body,
         HttpHeaders.EMPTY,
         ExceptionType.INTERNAL_SERVER_ERROR.getHttpStatus(),
-        request
-    );
+        request);
   }
 }

--- a/be/src/main/java/yeonba/be/exception/ExceptionAdvice.java
+++ b/be/src/main/java/yeonba/be/exception/ExceptionAdvice.java
@@ -20,13 +20,13 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
       HttpServletRequest request
   ) {
 
-    return handlerExceptionInternal(
+    return handleExceptionInternal(
         exception,
         request
     );
   }
 
-  private ResponseEntity<Object> handlerExceptionInternal(
+  private ResponseEntity<Object> handleExceptionInternal(
       GeneralException exception,
       HttpServletRequest request
   ) {

--- a/be/src/main/java/yeonba/be/exception/ExceptionAdvice.java
+++ b/be/src/main/java/yeonba/be/exception/ExceptionAdvice.java
@@ -47,6 +47,19 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
     );
   }
 
+  @ExceptionHandler
+  public ResponseEntity<Object> handleAllException(
+      Exception exception,
+      WebRequest request
+  ) {
+
+    return handleExceptionInternal(
+        exception,
+        request,
+        exception.getMessage()
+    );
+  }
+
   private ResponseEntity<Object> handleExceptionInternal(
       GeneralException exception,
       HttpServletRequest request
@@ -100,6 +113,25 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
         body,
         HttpHeaders.EMPTY,
         ExceptionType.BAD_REQUEST.getHttpStatus(),
+        request
+    );
+  }
+
+  private ResponseEntity<Object> handleExceptionInternal(
+      Exception exception,
+      WebRequest request,
+      String errorPoint
+  ) {
+
+    CustomResponse<String> body = CustomResponse.onFailure(
+        ExceptionType.INTERNAL_SERVER_ERROR.getReason(),
+        errorPoint
+    );
+    return super.handleExceptionInternal(
+        exception,
+        body,
+        HttpHeaders.EMPTY,
+        ExceptionType.INTERNAL_SERVER_ERROR.getHttpStatus(),
         request
     );
   }

--- a/be/src/main/java/yeonba/be/exception/ExceptionAdvice.java
+++ b/be/src/main/java/yeonba/be/exception/ExceptionAdvice.java
@@ -1,0 +1,44 @@
+package yeonba.be.exception;
+
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.ServletWebRequest;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+import yeonba.be.util.CustomResponse;
+
+@RestControllerAdvice(annotations = {RestController.class})
+public class ExceptionAdvice extends ResponseEntityExceptionHandler {
+
+  @ExceptionHandler(value = GeneralException.class)
+  public ResponseEntity<Object> handleGeneralException(
+      GeneralException exception,
+      HttpServletRequest request
+  ) {
+
+    return handlerExceptionInternal(
+        exception,
+        request
+    );
+  }
+
+  private ResponseEntity<Object> handlerExceptionInternal(
+      GeneralException exception,
+      HttpServletRequest request
+  ) {
+
+    CustomResponse<Object> body = new CustomResponse<>(exception.getExceptionReason());
+    WebRequest webRequest = new ServletWebRequest(request);
+    return super.handleExceptionInternal(
+        exception,
+        body,
+        HttpHeaders.EMPTY,
+        exception.getHttpStatus(),
+        webRequest
+    );
+  }
+}

--- a/be/src/main/java/yeonba/be/exception/ExceptionType.java
+++ b/be/src/main/java/yeonba/be/exception/ExceptionType.java
@@ -8,27 +8,21 @@ public enum ExceptionType {
 
   BAD_REQUEST(
       HttpStatus.BAD_REQUEST,
-      "COMMON400",
       "잘못된 요청입니다."),
 
   INTERNAL_SERVER_ERROR(
       HttpStatus.INTERNAL_SERVER_ERROR,
-      "COMMON500",
       "서버 에러 관리자에게 문의 바랍니다."),
 
-  // 서비스 고유 예외 코드 형식 : {관련 엔티티 이름(대문자)}{HTTP 응답 코드}{고유 번호}
   USER_NOT_FOUND(
       HttpStatus.BAD_REQUEST,
-      "USER4001",
       "해당 사용자가 존재하지 않습니다.");
 
   private final HttpStatus httpStatus;
-  private final String code;
   private final String reason;
 
-  ExceptionType(HttpStatus httpStatus, String code, String reason) {
+  ExceptionType(HttpStatus httpStatus, String reason) {
     this.httpStatus = httpStatus;
-    this.code = code;
     this.reason = reason;
   }
 }

--- a/be/src/main/java/yeonba/be/exception/ExceptionType.java
+++ b/be/src/main/java/yeonba/be/exception/ExceptionType.java
@@ -1,0 +1,30 @@
+package yeonba.be.exception;
+
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ExceptionType {
+  INTERNAL_SERVER_ERROR(
+      HttpStatus.INTERNAL_SERVER_ERROR,
+      "COMMON500",
+      "서버 에러 관리자에게 문의 바랍니다."
+  ),
+
+  // 서비스 고유 예외 코드 형식 : {관련 엔티티 이름(대문자)}{HTTP 응답 코드}{고유 번호}
+  USER_NOT_FOUND(
+      HttpStatus.BAD_REQUEST,
+      "USER4001",
+      "해당 사용자가 존재하지 않습니다."
+  );
+
+  private final HttpStatus httpStatus;
+  private final String code;
+  private final String reason;
+
+  ExceptionType(HttpStatus httpStatus, String code, String reason) {
+    this.httpStatus = httpStatus;
+    this.code = code;
+    this.reason = reason;
+  }
+}

--- a/be/src/main/java/yeonba/be/exception/ExceptionType.java
+++ b/be/src/main/java/yeonba/be/exception/ExceptionType.java
@@ -5,6 +5,13 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum ExceptionType {
+
+  BAD_REQUEST(
+      HttpStatus.BAD_REQUEST,
+      "COMMON400",
+      "잘못된 요청입니다."
+  ),
+
   INTERNAL_SERVER_ERROR(
       HttpStatus.INTERNAL_SERVER_ERROR,
       "COMMON500",

--- a/be/src/main/java/yeonba/be/exception/ExceptionType.java
+++ b/be/src/main/java/yeonba/be/exception/ExceptionType.java
@@ -9,21 +9,18 @@ public enum ExceptionType {
   BAD_REQUEST(
       HttpStatus.BAD_REQUEST,
       "COMMON400",
-      "잘못된 요청입니다."
-  ),
+      "잘못된 요청입니다."),
 
   INTERNAL_SERVER_ERROR(
       HttpStatus.INTERNAL_SERVER_ERROR,
       "COMMON500",
-      "서버 에러 관리자에게 문의 바랍니다."
-  ),
+      "서버 에러 관리자에게 문의 바랍니다."),
 
   // 서비스 고유 예외 코드 형식 : {관련 엔티티 이름(대문자)}{HTTP 응답 코드}{고유 번호}
   USER_NOT_FOUND(
       HttpStatus.BAD_REQUEST,
       "USER4001",
-      "해당 사용자가 존재하지 않습니다."
-  );
+      "해당 사용자가 존재하지 않습니다.");
 
   private final HttpStatus httpStatus;
   private final String code;

--- a/be/src/main/java/yeonba/be/exception/GeneralException.java
+++ b/be/src/main/java/yeonba/be/exception/GeneralException.java
@@ -1,0 +1,22 @@
+package yeonba.be.exception;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@RequiredArgsConstructor
+public class GeneralException extends RuntimeException {
+
+  private final ExceptionType exceptionType;
+
+  public HttpStatus getHttpStatus() {
+    return exceptionType.getHttpStatus();
+  }
+
+  public String getExceptionReason() {
+    return exceptionType.getReason();
+  }
+
+  public String getExceptionCode() {
+    return exceptionType.getCode();
+  }
+}

--- a/be/src/main/java/yeonba/be/util/CustomResponse.java
+++ b/be/src/main/java/yeonba/be/util/CustomResponse.java
@@ -4,27 +4,38 @@ import lombok.Getter;
 
 @Getter
 public class CustomResponse<T> {
-    private final String status;
 
-    private final String message;
+  private final String status;
 
-    private final T data;
+  private final String message;
 
-    public CustomResponse(String message) {
-        this.status = "fail";
-        this.message = message;
-        this.data = null;
-    }
+  private final T data;
 
-    public CustomResponse(T data) {
-        this.status = "success";
-        this.message = null;
-        this.data = data;
-    }
+  public CustomResponse(String message) {
+    this.status = "fail";
+    this.message = message;
+    this.data = null;
+  }
 
-    public CustomResponse() {
-        this.status = "success";
-        this.message = null;
-        this.data = null;
-    }
+  public CustomResponse(T data) {
+    this.status = "success";
+    this.message = null;
+    this.data = data;
+  }
+
+  public CustomResponse() {
+    this.status = "success";
+    this.message = null;
+    this.data = null;
+  }
+
+  private CustomResponse(String message, T data) {
+    this.status = "fail";
+    this.message = message;
+    this.data = data;
+  }
+
+  public static <T> CustomResponse<T> onFailure(String message, T data) {
+    return new CustomResponse<>(message, data);
+  }
 }

--- a/be/src/main/java/yeonba/be/util/CustomResponse.java
+++ b/be/src/main/java/yeonba/be/util/CustomResponse.java
@@ -36,6 +36,7 @@ public class CustomResponse<T> {
   }
 
   public static <T> CustomResponse<T> onFailure(String message, T data) {
+
     return new CustomResponse<>(message, data);
   }
 }


### PR DESCRIPTION
## 작업 대상

<!-- 작업한 대상을 자세히 설명해주세요. -->

- `ExceptionType` : 예외 데이터 처리를 위한 `enum`
- `GeneralException` : 커스텀 예외
- `ExceptionAdvice` : 전역 예외 처리

## 📄 작업 내용

<!-- 작업한 내용을 간단히 요약해주세요. -->

- spring에서 제공하는 `ResponseEntityExceptionHandler` 이용 ExceptionAdvice 구현
- `ResponseEntityExceptionHandler`를 활용하여 `Spring MVC`에서 발생 가능한 모든 예외 커스텀 처리 가능
- 크게 다음 4가지 종류의 예외를 구분하여 처리하도록 로직 구성
    - `GeneralException` : 서비스 고유 예외
    - `MethodArgumentException` : `@Valid` 에서 발생
    - `ConstraintViolationException` : `@Positive` , `@Size` 등의 제약 조건 위반 시 발생
    - 이외 예외(`Exception` )
- 기존의 `CustomResponse` 를 활용하여 예외 상황에 대해서도 일관되게 응답

## 🙋🏻 주의 사항

<!-- 리뷰어를 위해 복잡하거나 중요한 코드를 명시해주세요. -->

- `MethodArgumentException` 의 경우 한 번에 여러 검증 예외가 발생할 수 있어 예외가 발생한 부분(field)을 키로 하고 
값을 예외 메시지로 하는 `Map<String,String>` 형태로 응답 데이터를 구성
- 기존 `CustomResponse` 생성자중 예외 상황에서 응답 데이터를 포함할 수 있는 형태가 없어 별도의 
`onFailure` 팩토리 메서드 구현
- 위 팩토리 메서드를 활용하여 `MethodArgumentException` 발생시 응답 데이터로 예외 정보를 담은 `Map` 을 
전달하도록 예외 처리 로직 구성

## 📎 관련 이슈

- 예외의 종류가 달라도 다 `400 Bad Request` 로 취급될 수 있는 경우가 많은데 예외마다 식별 코드를 부여해 
구분하고 예외 응답시 이 코드도 함께 전달하는 것을 어떻게 생각하는지?

## 레퍼런스

<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->
- [Spring Exception 전략](https://cheese10yun.github.io/spring-guide-exception/)

- [ResponseEntityExceptionHandler를 사용해야 하는 이유](https://velog.io/@appti/ResponseEntityExceptionHandler%EB%A5%BC-%EC%82%AC%EC%9A%A9%ED%95%B4%EC%95%BC-%ED%95%98%EB%8A%94-%EC%9D%B4%EC%9C%A0#responseentityexceptionhandler)