### PR TITLE
[동일 객체 비교 로직 제안] EqualsAndHashCode를 활용해 동일 객체 비교 로직 제안(#31)

### DIFF
--- a/be/src/main/java/yeonba/be/user/entity/User.java
+++ b/be/src/main/java/yeonba/be/user/entity/User.java
@@ -105,6 +105,13 @@ public class User {
         }
     }
 
+    public void validateNotSameUser(User user) {
+
+        if (this.equals(user)) {
+            throw new IllegalArgumentException("동일한 사용자입니다.");
+        }
+    }
+
     public void changePassword(String encryptedNewPassword) {
 
         this.encryptedPassword = encryptedNewPassword;

--- a/be/src/main/java/yeonba/be/user/entity/User.java
+++ b/be/src/main/java/yeonba/be/user/entity/User.java
@@ -13,6 +13,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -21,6 +22,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode(of = "id")
 public class User {
 
     @Id
@@ -94,6 +96,13 @@ public class User {
         this.smokingHabit = smokingHabit;
         this.mbti = mbti;
         this.lastAccessedAt = lastAccessedAt;
+    }
+
+    public void validateSameUser(User user) {
+
+        if (!this.equals(user)) {
+            throw new IllegalArgumentException("동일한 사용자가 아닙니다.");
+        }
     }
 
     public void changePassword(String encryptedNewPassword) {


### PR DESCRIPTION
## 작업 대상
- User Entity


## 📄 작업 내용
- Lombok의 EuqalsAndHashCode를 활용해 동일 객체 비교 로직 추가


## 🙋🏻 주의 사항


## 📎 관련 이슈
- EqualsAndHashCode를 활용해 id가 같은 객체들을 동일한 객체로 인식할 수 있도록 합니다.
- 어떤 데이터를 수정할 때 본인만 할 수 있는 기능을 해당 PR에 추가한 메서드로 검증할 수 있습니다.
- 이를 응용하여, `본인은 신고할 수 없다`, `본인에게는 화살을 보낼 수 없다` 등의 요구사항에서 활용할 수 있습니다.


## 레퍼런스
<!-- 작업 시 참고했던 문건의 URL을 남겨주세요 -->
